### PR TITLE
Add data source of GitHub URL

### DIFF
--- a/lib/gems_comparator/gem_info.rb
+++ b/lib/gems_comparator/gem_info.rb
@@ -26,6 +26,8 @@ module GemsComparator
     def github_url
       if GithubRepository.repo?(homepage)
         homepage
+      elsif GithubRepository.repo?(source_code_uri)
+        source_code_uri
       elsif github_urls.key?(name)
         "https://github.com/#{github_urls[name]}"
       end
@@ -56,6 +58,10 @@ module GemsComparator
         "#{Bundler.specs_path}/#{name}-#{after}.gemspec"
       ]
       spec_paths.find { |path| File.exist?(path) }
+    end
+
+    def source_code_uri
+      spec&.metadata&.fetch('source_code_uri', nil)
     end
   end
 end

--- a/spec/fixtures/activerecord-5.2.0.gemspec
+++ b/spec/fixtures/activerecord-5.2.0.gemspec
@@ -1,0 +1,43 @@
+# -*- encoding: utf-8 -*-
+# stub: activerecord 5.2.0 ruby lib
+
+Gem::Specification.new do |s|
+  s.name = "activerecord".freeze
+  s.version = "5.2.0"
+
+  s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
+  s.metadata = { "changelog_uri" => "https://github.com/rails/rails/blob/v5.2.0/activerecord/CHANGELOG.md", "source_code_uri" => "https://github.com/rails/rails/tree/v5.2.0/activerecord" } if s.respond_to? :metadata=
+  s.require_paths = ["lib".freeze]
+  s.authors = ["David Heinemeier Hansson".freeze]
+  s.date = "2018-04-09"
+  s.description = "Databases on Rails. Build a persistent domain model by mapping database tables to Ruby classes. Strong conventions for associations, validations, aggregations, migrations, and testing come baked-in.".freeze
+  s.email = "david@loudthinking.com".freeze
+  s.extra_rdoc_files = ["README.rdoc".freeze]
+  s.files = ["README.rdoc".freeze]
+  s.homepage = "http://rubyonrails.org".freeze
+  s.licenses = ["MIT".freeze]
+  s.rdoc_options = ["--main".freeze, "README.rdoc".freeze]
+  s.required_ruby_version = Gem::Requirement.new(">= 2.2.2".freeze)
+  s.rubygems_version = "2.7.6".freeze
+  s.summary = "Object-relational mapper framework (part of Rails).".freeze
+
+  s.installed_by_version = "2.7.6" if s.respond_to? :installed_by_version
+
+  if s.respond_to? :specification_version then
+    s.specification_version = 4
+
+    if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
+      s.add_runtime_dependency(%q<activesupport>.freeze, ["= 5.2.0"])
+      s.add_runtime_dependency(%q<activemodel>.freeze, ["= 5.2.0"])
+      s.add_runtime_dependency(%q<arel>.freeze, [">= 9.0"])
+    else
+      s.add_dependency(%q<activesupport>.freeze, ["= 5.2.0"])
+      s.add_dependency(%q<activemodel>.freeze, ["= 5.2.0"])
+      s.add_dependency(%q<arel>.freeze, [">= 9.0"])
+    end
+  else
+    s.add_dependency(%q<activesupport>.freeze, ["= 5.2.0"])
+    s.add_dependency(%q<activemodel>.freeze, ["= 5.2.0"])
+    s.add_dependency(%q<arel>.freeze, [">= 9.0"])
+  end
+end

--- a/spec/fixtures/activerecord-5.2.1.gemspec
+++ b/spec/fixtures/activerecord-5.2.1.gemspec
@@ -1,0 +1,43 @@
+# -*- encoding: utf-8 -*-
+# stub: activerecord 5.2.1 ruby lib
+
+Gem::Specification.new do |s|
+  s.name = "activerecord".freeze
+  s.version = "5.2.1"
+
+  s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
+  s.metadata = { "changelog_uri" => "https://github.com/rails/rails/blob/v5.2.1/activerecord/CHANGELOG.md", "source_code_uri" => "https://github.com/rails/rails/tree/v5.2.1/activerecord" } if s.respond_to? :metadata=
+  s.require_paths = ["lib".freeze]
+  s.authors = ["David Heinemeier Hansson".freeze]
+  s.date = "2018-08-07"
+  s.description = "Databases on Rails. Build a persistent domain model by mapping database tables to Ruby classes. Strong conventions for associations, validations, aggregations, migrations, and testing come baked-in.".freeze
+  s.email = "david@loudthinking.com".freeze
+  s.extra_rdoc_files = ["README.rdoc".freeze]
+  s.files = ["README.rdoc".freeze]
+  s.homepage = "http://rubyonrails.org".freeze
+  s.licenses = ["MIT".freeze]
+  s.rdoc_options = ["--main".freeze, "README.rdoc".freeze]
+  s.required_ruby_version = Gem::Requirement.new(">= 2.2.2".freeze)
+  s.rubygems_version = "2.7.6".freeze
+  s.summary = "Object-relational mapper framework (part of Rails).".freeze
+
+  s.installed_by_version = "2.7.6" if s.respond_to? :installed_by_version
+
+  if s.respond_to? :specification_version then
+    s.specification_version = 4
+
+    if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
+      s.add_runtime_dependency(%q<activesupport>.freeze, ["= 5.2.1"])
+      s.add_runtime_dependency(%q<activemodel>.freeze, ["= 5.2.1"])
+      s.add_runtime_dependency(%q<arel>.freeze, [">= 9.0"])
+    else
+      s.add_dependency(%q<activesupport>.freeze, ["= 5.2.1"])
+      s.add_dependency(%q<activemodel>.freeze, ["= 5.2.1"])
+      s.add_dependency(%q<arel>.freeze, [">= 9.0"])
+    end
+  else
+    s.add_dependency(%q<activesupport>.freeze, ["= 5.2.1"])
+    s.add_dependency(%q<activemodel>.freeze, ["= 5.2.1"])
+    s.add_dependency(%q<arel>.freeze, [">= 9.0"])
+  end
+end

--- a/spec/gems_comparator/gem_info_spec.rb
+++ b/spec/gems_comparator/gem_info_spec.rb
@@ -22,9 +22,18 @@ module GemsComparator
     end
 
     describe '#github_url' do
-      let(:gem_info) { GemInfo.new('action_args', '0.1.0', '0.2.0') }
+      context "when homepage isn't GitHub url and source_code_uri is it" do
+        let(:gem_info) { GemInfo.new('activerecord', '5.2.0', '5.2.1') }
 
-      context "when homepage isn't GitHub url" do
+        it 'should return source_code_uri' do
+          expected = 'https://github.com/rails/rails/tree/v5.2.0/activerecord'
+          expect(gem_info.github_url).to eq expected
+        end
+      end
+
+      context "when homepage and source_code_uri aren't GitHub url" do
+        let(:gem_info) { GemInfo.new('action_args', '0.1.0', '0.2.0') }
+
         it 'should return url from github_urls.yml' do
           homepage = 'http://asakusa.rubyist.net/'
           allow(gem_info).to receive(:homepage) { homepage }


### PR DESCRIPTION
Hi, @sinsoku 

I added [`source_code_uri` metadata](https://guides.rubygems.org/specification-reference/#metadata) as data source of GitHub URL.
It is used to store GitHub URL in gem such as [bundler](https://github.com/bundler/bundler/blob/v1.16.3/bundler.gemspec#L26), [activerecord](https://github.com/rails/rails/blob/v5.2.1/activerecord/activerecord.gemspec#L27), and [oj](https://github.com/ohler55/oj/blob/v3.6.5/oj.gemspec#L17).

I changed to use `source_code_uri` value as GitHub URL if homepage is not GitHub URL and `source_code_uri` metadata is GitHub URL.