### PR TITLE
use actionable code coverage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,3 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in gems_comparator.gemspec
 gemspec
-
-gem 'codecov', require: false

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Gem Version](https://badge.fury.io/rb/gems_comparator.svg)](https://badge.fury.io/rb/gems_comparator)
 [![Build Status](https://travis-ci.org/sinsoku/gems_comparator.svg?branch=master)](https://travis-ci.org/sinsoku/gems_comparator)
-[![codecov](https://codecov.io/gh/sinsoku/gems_comparator/branch/master/graph/badge.svg)](https://codecov.io/gh/sinsoku/gems_comparator)
+![Coverage](https://img.shields.io/badge/Coverage-100%25-green.svg)
 
 GemsComparator generates GitHub's compare view urls from the difference between two `Gemfile.lock`.
 

--- a/gems_comparator.gemspec
+++ b/gems_comparator.gemspec
@@ -27,5 +27,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop', '0.59.2'
+  spec.add_development_dependency 'single_cov', '~> 1.3.0'
   spec.add_development_dependency 'webmock', '~> 2.3.2'
 end

--- a/spec/gems_comparator/comparator_spec.rb
+++ b/spec/gems_comparator/comparator_spec.rb
@@ -2,6 +2,8 @@
 
 require 'spec_helper'
 
+SingleCov.covered!
+
 module GemsComparator
   describe Comparator do
     describe '.convert' do

--- a/spec/gems_comparator/gem_info_spec.rb
+++ b/spec/gems_comparator/gem_info_spec.rb
@@ -2,18 +2,25 @@
 
 require 'spec_helper'
 
+SingleCov.covered!
+
 module GemsComparator
   describe GemInfo do
     describe '#compare_url' do
       let(:gem_info) { GemInfo.new('gems_comparator', '0.1.0', '0.2.0') }
       let(:url) { 'https://api.github.com/repos/sinsoku/gems_comparator/tags' }
 
-      before do
-        stub_octokit(:get, '/repos/sinsoku/gems_comparator/tags')
-          .to_return(status: 404)
+      it 'shows nothing when url is not set' do
+        gem_info = GemInfo.new('foo', '0.1.0', '0.2.0')
+        expect(gem_info.compare_url).to eq nil
       end
 
       context 'when an error occurs' do
+        before do
+          stub_octokit(:get, '/repos/sinsoku/gems_comparator/tags')
+            .to_return(status: 404)
+        end
+
         it do
           error_message = "#<Octokit::NotFound: GET #{url}: 404 - >"
           expect(gem_info.compare_url).to eq error_message

--- a/spec/gems_comparator/github_repository_spec.rb
+++ b/spec/gems_comparator/github_repository_spec.rb
@@ -2,23 +2,36 @@
 
 require 'spec_helper'
 
+SingleCov.covered!
+
 module GemsComparator
   describe GithubRepository do
-    describe '.url?' do
+    describe '.repo?' do
       context 'when given a repo url' do
         let(:url) { 'https://github.com/sinsoku/gems_comparator' }
-        it { expect(GithubRepository).to be_repo url }
+        it { expect(GithubRepository.repo?(url)).to eq true }
+      end
+
+      context 'when given a bad repo url' do
+        let(:url) { 'github.comwhoops' }
+        it { expect(GithubRepository.repo?(url)).to eq false }
       end
 
       context 'when given another url' do
         let(:url) { 'http://rubyonrails.org' }
-        it { expect(GithubRepository).to_not be_repo url }
+        it { expect(GithubRepository.repo?(url)).to eq false }
       end
     end
 
     describe '#compare' do
       let(:url) { 'https://github.com/sinsoku/gems_comparator' }
       let(:repo) { GithubRepository.new(url) }
+
+      it 'ignores when tag is not set' do
+        stub_octokit(:get, '/repos/sinsoku/gems_comparator/tags')
+          .to_return(body: JSON.dump([]))
+        expect(repo.compare('0.1.0', '')).to eq nil
+      end
 
       context 'when tags found' do
         let(:tags) { [{ name: 'v0.1.0' }, { name: 'v0.2.0' }] }

--- a/spec/gems_comparator_spec.rb
+++ b/spec/gems_comparator_spec.rb
@@ -2,6 +2,8 @@
 
 require 'spec_helper'
 
+SingleCov.covered!
+
 describe GemsComparator do
   describe '.configure' do
     let(:client) { Octokit::Client.new }
@@ -11,6 +13,12 @@ describe GemsComparator do
         config.client = client
       end
       expect(GemsComparator.config.client).to eq client
+    end
+  end
+
+  describe '.compare' do
+    it 'can compare' do
+      expect(GemsComparator.compare('', '')).to eq([])
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,12 +2,8 @@
 
 $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 
-require 'simplecov'
-SimpleCov.start
-if ENV['CI'] == 'true'
-  require 'codecov'
-  SimpleCov.formatter = SimpleCov::Formatter::Codecov
-end
+require 'single_cov'
+SingleCov.setup :rspec
 
 require 'gems_comparator'
 require 'webmock/rspec'


### PR DESCRIPTION
now if anyone adds new uncovered code the build will just fail and tell them what needs fixing ... no more hopping into github UI to find things :)
(also adds branch coverage)

@sinsoku 

```
Lines missing coverage:
lib/gems_comparator/github_repository.rb:30
```