### PR TITLE
Improve `GemInfo#github_url`

### DIFF
--- a/lib/gems_comparator/gem_info.rb
+++ b/lib/gems_comparator/gem_info.rb
@@ -24,7 +24,9 @@ module GemsComparator
     end
 
     def github_url
-      @github_url ||= [
+      return @github_url if instance_variable_defined?(:@github_url)
+
+      @github_url = [
         source_code_uri,
         homepage,
         github_url_from_yaml

--- a/lib/gems_comparator/gem_info.rb
+++ b/lib/gems_comparator/gem_info.rb
@@ -24,8 +24,11 @@ module GemsComparator
     end
 
     def github_url
-      urls = [source_code_uri, homepage, github_url_from_yaml]
-      urls.map(&method(:normalized_github_url)).compact.first
+      @github_url ||= [
+        source_code_uri,
+        homepage,
+        github_url_from_yaml
+      ].map(&method(:normalized_github_url)).compact.first
     end
 
     def homepage

--- a/lib/gems_comparator/gem_info.rb
+++ b/lib/gems_comparator/gem_info.rb
@@ -24,7 +24,7 @@ module GemsComparator
     end
 
     def github_url
-      urls = [homepage, source_code_uri, github_url_from_yaml]
+      urls = [source_code_uri, homepage, github_url_from_yaml]
       urls.map(&method(:normalized_github_url)).compact.first
     end
 

--- a/spec/fixtures/turbolinks-5.2.0.gemspec
+++ b/spec/fixtures/turbolinks-5.2.0.gemspec
@@ -1,0 +1,32 @@
+# -*- encoding: utf-8 -*-
+# stub: turbolinks 5.2.0 ruby lib
+
+Gem::Specification.new do |s|
+  s.name = "turbolinks".freeze
+  s.version = "5.2.0"
+
+  s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
+  s.require_paths = ["lib".freeze]
+  s.authors = ["David Heinemeier Hansson".freeze]
+  s.date = "2018-08-20"
+  s.description = "Rails engine for Turbolinks 5 support".freeze
+  s.email = "david@loudthinking.com".freeze
+  s.homepage = "https://github.com/turbolinks/turbolinks".freeze
+  s.licenses = ["MIT".freeze]
+  s.rubygems_version = "2.7.6".freeze
+  s.summary = "Turbolinks makes navigating your web application faster".freeze
+
+  s.installed_by_version = "2.7.6" if s.respond_to? :installed_by_version
+
+  if s.respond_to? :specification_version then
+    s.specification_version = 4
+
+    if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
+      s.add_runtime_dependency(%q<turbolinks-source>.freeze, ["~> 5.2"])
+    else
+      s.add_dependency(%q<turbolinks-source>.freeze, ["~> 5.2"])
+    end
+  else
+    s.add_dependency(%q<turbolinks-source>.freeze, ["~> 5.2"])
+  end
+end

--- a/spec/fixtures/turbolinks-5.2.1.gemspec
+++ b/spec/fixtures/turbolinks-5.2.1.gemspec
@@ -1,0 +1,33 @@
+# -*- encoding: utf-8 -*-
+# stub: turbolinks 5.2.1 ruby lib
+
+Gem::Specification.new do |s|
+  s.name = "turbolinks".freeze
+  s.version = "5.2.1"
+
+  s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
+  s.metadata = { "source_code_uri" => "https://github.com/turbolinks/turbolinks-rails" } if s.respond_to? :metadata=
+  s.require_paths = ["lib".freeze]
+  s.authors = ["David Heinemeier Hansson".freeze]
+  s.date = "2019-09-18"
+  s.description = "Rails engine for Turbolinks 5 support".freeze
+  s.email = "david@loudthinking.com".freeze
+  s.homepage = "https://github.com/turbolinks/turbolinks".freeze
+  s.licenses = ["MIT".freeze]
+  s.rubygems_version = "2.7.6".freeze
+  s.summary = "Turbolinks makes navigating your web application faster".freeze
+
+  s.installed_by_version = "2.7.6" if s.respond_to? :installed_by_version
+
+  if s.respond_to? :specification_version then
+    s.specification_version = 4
+
+    if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
+      s.add_runtime_dependency(%q<turbolinks-source>.freeze, ["~> 5.2"])
+    else
+      s.add_dependency(%q<turbolinks-source>.freeze, ["~> 5.2"])
+    end
+  else
+    s.add_dependency(%q<turbolinks-source>.freeze, ["~> 5.2"])
+  end
+end

--- a/spec/gems_comparator/gem_info_spec.rb
+++ b/spec/gems_comparator/gem_info_spec.rb
@@ -42,6 +42,15 @@ module GemsComparator
           expect(gem_info.github_url).to eq expected
         end
       end
+
+      context 'when homepage and source_code_uri are not same GitHub url' do
+        let(:gem_info) { GemInfo.new('turbolinks', '5.2.0', '5.2.1') }
+
+        it 'should return source_code_uri' do
+          expected = 'https://github.com/turbolinks/turbolinks-rails'
+          expect(gem_info.github_url).to eq expected
+        end
+      end
     end
 
     describe '#to_h' do


### PR DESCRIPTION
Hi, @sinsoku

I changed following changes to `GemInfo#github_url` method.

* Change data source priority
  * If `homepage` and `source_code_uri` set GitHub URL, but not same URL, `source_code_uri` should be given priority in `GemInfo#github_url‘
* Memorize
  * Called multiple times in `GemInfo#compare_url`