### PR TITLE
Support for 4 digits version numbers

### DIFF
--- a/lib/gems_comparator/github_repository.rb
+++ b/lib/gems_comparator/github_repository.rb
@@ -35,7 +35,7 @@ module GemsComparator
     def find_tag(name)
       return if name.empty?
 
-      tag_names.find { |tag_name| tag_name.include?(name) }
+      tag_names.find { |tag_name| tag_name.end_with?(name) }
     end
 
     def client

--- a/spec/gems_comparator/github_repository_spec.rb
+++ b/spec/gems_comparator/github_repository_spec.rb
@@ -61,6 +61,17 @@ module GemsComparator
         subject { repo.compare('0.1.0', '0.2.0') }
         it { is_expected.to eq "#{url}/compare/version-0.1.0...version-0.2.0" }
       end
+
+      context 'when the tag name is 4 digits versioning like as Rails' do
+        let(:tags) { [{ name: 'v7.0.2.1' }, { name: 'v7.0.2' }] }
+
+        before do
+          stub_octokit(:get, '/repos/sinsoku/gems_comparator/tags')
+            .to_return(body: JSON.dump(tags))
+        end
+        subject { repo.compare('7.0.2', '7.0.2.1') }
+        it { is_expected.to eq "#{url}/compare/v7.0.2...v7.0.2.1" }
+      end
     end
   end
 end


### PR DESCRIPTION
Hi @sinsoku ,

I've added support for version numbers like Rails, where the version number may have 4 digits.

### before
```ruby
GemsComparator::GithubRepository.new('https://github.com/rails/rails').compare('7.0.2', '7.0.2.2')
# => "https://github.com/rails/rails/compare/v7.0.2.2...v7.0.2.2"
```

### after
```ruby
GemsComparator::GithubRepository.new('https://github.com/rails/rails').compare('7.0.2', '7.0.2.2')
# => "https://github.com/rails/rails/compare/v7.0.2...v7.0.2.2"
```